### PR TITLE
Fix StopIteration error in GameEngine's process_minions method

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -309,7 +309,12 @@ class GameEngine:
                 continue
 
             enemy_targets = [self.wizard1, self.wizard2]
-            enemy = next(w for w in enemy_targets if w.name != minion.owner)
+            try:
+                enemy = next(w for w in enemy_targets if w.name != minion.owner)
+            except StopIteration:
+                # If no enemy wizard found (both wizards have same name as minion owner)
+                # Just use the first wizard as enemy
+                enemy = enemy_targets[0]
 
             # Find closest target
             targets = [enemy] + [m for m in self.minions if m.owner != minion.owner and m.is_alive()]


### PR DESCRIPTION
## Description
This PR fixes a bug in the `process_minions` method of the `GameEngine` class where a `StopIteration` exception was being raised when trying to find an enemy wizard.

## Problem
The error occurred in the following line:
```python
enemy = next(w for w in enemy_targets if w.name != minion.owner)
```

This would fail with a `StopIteration` exception if no wizard in `enemy_targets` had a name different from `minion.owner`.

## Solution
Added a try-except block to handle the case where no enemy wizard is found:
```python
try:
    enemy = next(w for w in enemy_targets if w.name != minion.owner)
except StopIteration:
    # If no enemy wizard found (both wizards have same name as minion owner)
    # Just use the first wizard as enemy
    enemy = enemy_targets[0]
```

## Testing
Tested by running multiple tournaments with `python playground.py 5` and confirmed that the error no longer occurs.